### PR TITLE
Remove debug "stop" statement

### DIFF
--- a/socket.go
+++ b/socket.go
@@ -138,7 +138,6 @@ func (s *Server) Run() error {
 
 // Stop will stop the server
 func (s *Server) Stop() {
-	fmt.Println("Stop")
 	s.stopChan <- struct{}{}
 	_ = s.listener.Close()
 }


### PR DESCRIPTION
currently, we print "Stop" wot stdout when stopping. this is not needed and interferes with JSON parsing out the logs.